### PR TITLE
feat: add basic ecommerce skeleton

### DIFF
--- a/app/catalog/page.tsx
+++ b/app/catalog/page.tsx
@@ -1,0 +1,12 @@
+import ProductCard from '@/components/ProductCard';
+import { products } from '@/data/products';
+
+export default function CatalogPage() {
+  return (
+    <main className="p-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      {products.map((product) => (
+        <ProductCard key={product.id} product={product} />
+      ))}
+    </main>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,19 @@
+import './globals.css';
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Demo Shop',
+  description: 'Simple e-commerce MVP',
+};
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="ru">
+      <body className="min-h-screen bg-white text-gray-900">{children}</body>
+    </html>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,12 @@
+import Link from 'next/link';
+
+export default function HomePage() {
+  return (
+    <main className="p-6">
+      <h1 className="text-2xl font-bold mb-4">Интернет-магазин</h1>
+      <Link className="text-blue-600 underline" href="/catalog">
+        Перейти в каталог
+      </Link>
+    </main>
+  );
+}

--- a/app/product/[slug]/page.tsx
+++ b/app/product/[slug]/page.tsx
@@ -1,0 +1,17 @@
+import { products } from '@/data/products';
+interface ProductPageProps {
+  params: { slug: string };
+}
+
+export default function ProductPage({ params }: ProductPageProps) {
+  const product = products.find((p) => p.slug === params.slug);
+  if (!product) {
+    return <main className="p-6">Товар не найден</main>;
+  }
+  return (
+    <main className="p-6">
+      <h1 className="text-2xl font-bold mb-4">{product.title}</h1>
+      <p className="mb-2">Цена: {product.price} MDL</p>
+    </main>
+  );
+}

--- a/components/ProductCard.tsx
+++ b/components/ProductCard.tsx
@@ -1,0 +1,31 @@
+import Image from 'next/image';
+import Link from 'next/link';
+import { Product } from '@/data/products';
+
+interface ProductCardProps {
+  product: Product;
+}
+
+export default function ProductCard({ product }: ProductCardProps) {
+  return (
+    <div className="border rounded p-2 flex flex-col">
+      {product.image && (
+        <Image
+          src={product.image}
+          alt={product.title}
+          width={300}
+          height={300}
+          className="object-cover"
+        />
+      )}
+      <h2 className="mt-2 font-semibold">{product.title}</h2>
+      <p className="text-sm text-gray-500 mb-2">{product.price} MDL</p>
+      <Link
+        href={`/product/${product.slug}`}
+        className="mt-auto text-blue-600 underline"
+      >
+        Подробнее
+      </Link>
+    </div>
+  );
+}

--- a/data/products.ts
+++ b/data/products.ts
@@ -1,0 +1,24 @@
+export interface Product {
+  id: number;
+  slug: string;
+  title: string;
+  price: number;
+  image?: string;
+}
+
+export const products: Product[] = [
+  {
+    id: 1,
+    slug: 'sample-product',
+    title: 'Пример товара',
+    price: 1000,
+    image: 'https://via.placeholder.com/300'
+  },
+  {
+    id: 2,
+    slug: 'another-product',
+    title: 'Другой товар',
+    price: 1500,
+    image: 'https://via.placeholder.com/300'
+  }
+];


### PR DESCRIPTION
## Summary
- scaffold Next.js app with Tailwind
- add static catalog and product pages
- create reusable ProductCard component

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bfb95d1b2c832d8bb39757bfd80c32